### PR TITLE
Add the `Regex` string predicate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Adds the `Regex` predicate to `string`
 ## [0.0.3] - 2025-02-11
 
 - Updates documentation and readme to improve discoverability of provided refinements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +45,40 @@ dependencies = [
 name = "refined"
 version = "0.0.3"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/jkaye2012/refined"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+regex = { version = "1.11.1", optional = true }
 serde = { version = "1.0.217", features = ["derive"], optional = true }
 thiserror = "2.0.11"
 
@@ -17,6 +18,7 @@ serde_json = "1.0.138"
 [features]
 default = [ "serde" ]
 implication = []
+regex = [ "dep:regex" ]
 serde = [ "dep:serde" ]
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,8 @@
 //! * [boolean]: "combinator" refinements that allow other refinements to be combined with one another. Examples include
 //!   [And](boolean::And) and [Or](boolean::Or)
 //! * [character]: refinements of [char]. Examples include [IsLowercase](character::IsLowercase) and [IsWhitespace](character::IsWhitespace)
-//! * [string]: refinements of any type that implements [AsRef\<str\>](AsRef). Examples include [Contains](string::Contains) and
-//!   [Trimmed](string::Trimmed)
+//! * [string]: refinements of any type that implements [AsRef\<str\>](AsRef). Examples include [Contains](string::Contains),
+//!   [Trimmed](string::Trimmed), and [Regex](string::Regex)
 //!
 //! # Features
 //!


### PR DESCRIPTION
This predicate's state at the type level is a `TypeString`; when `test()` is inovked, it will make that string into a regular expression which will then be matched against the input.

The new predicate and it's unit test are gated by a new feature flag "regex".