### PR TITLE
Deprecates extract in favor of take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds the `StatefulPredicate and`StatefulRefinementOps` traits to allow for stateful refinement
 - Adds the `arithmetic` feature, allowing for simple arithmetic operations on `Refinement`
 - Refactors `NamedRefinement` into a generic `Named` wrapper
+- Deprecates `Refinement::extract` in favor of `Refinement::take` (via `RefinementOps`)
 
 ## [0.0.3] - 2025-02-11
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ pub trait RefinementOps:
     where
         F: FnOnce(Self::T) -> Self::T,
     {
-        Self::refine(fun(self.extract()))
+        Self::refine(fun(self.take()))
     }
 
     /// Attempts a replacement of a refined value, re-certifying that the predicate
@@ -434,6 +434,15 @@ pub trait RefinementOps:
     /// Destructively removes the refined value from the `Refinement` wrapper.
     ///
     /// For a non-destructive version, use the [std::ops::Deref] implementation instead.
+    fn take(self) -> Self::T;
+
+    /// Destructively removes the refined value from the `Refinement` wrapper.
+    ///
+    /// For a non-destructive version, use the [std::ops::Deref] implementation instead.
+    #[deprecated(
+        since = "0.0.4",
+        note = "use the more idiomatic 'take' function instead"
+    )]
     fn extract(self) -> Self::T;
 }
 
@@ -448,7 +457,7 @@ pub trait StatefulRefinementOps<T, P: StatefulPredicate<T>>: RefinementOps<T = T
     where
         F: FnOnce(<Self as RefinementOps>::T) -> <Self as RefinementOps>::T,
     {
-        Self::refine_with_state(predicate, fun(self.extract()))
+        Self::refine_with_state(predicate, fun(self.take()))
     }
 
     /// Attempts a replacement of a refined value, re-certifying that the stateful predicate

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -24,6 +24,10 @@ pub struct Refinement<T: Clone, P: Predicate<T> + Clone>(pub(crate) T, pub(crate
 impl<T: Clone, P: Predicate<T> + Clone> RefinementOps for Refinement<T, P> {
     type T = T;
 
+    fn take(self) -> T {
+        self.0
+    }
+
     fn extract(self) -> T {
         self.0
     }
@@ -157,9 +161,9 @@ mod tests {
     }
 
     #[test]
-    fn test_refinement_extract() {
+    fn test_refinement_take() {
         let value = Refinement::<u8, boundable::unsigned::LessThan<5>>(4, PhantomData);
-        let extracted = value.extract();
+        let extracted = value.take();
         assert_eq!(extracted, 4);
     }
 }

--- a/src/refinement/named.rs
+++ b/src/refinement/named.rs
@@ -53,15 +53,19 @@ impl<N: TypeString + Clone, R: Clone + RefinementOps> TryFrom<Refined<R::T>> for
 
 impl<N: TypeString + Clone, R: Clone + RefinementOps> From<Named<N, R>> for Refined<R::T> {
     fn from(value: Named<N, R>) -> Self {
-        Refined(value.extract())
+        Refined(value.take())
     }
 }
 
 impl<N: TypeString + Clone, R: Clone + RefinementOps> RefinementOps for Named<N, R> {
     type T = R::T;
 
+    fn take(self) -> Self::T {
+        self.0.take()
+    }
+
     fn extract(self) -> Self::T {
-        self.0.extract()
+        self.0.take()
     }
 }
 
@@ -132,7 +136,7 @@ mod named_serde {
         R::T: Serialize + DeserializeOwned,
     {
         fn from(value: NamedSerde<N, R>) -> Self {
-            Refined(value.extract())
+            Refined(value.take())
         }
     }
 
@@ -142,8 +146,12 @@ mod named_serde {
     {
         type T = R::T;
 
+        fn take(self) -> Self::T {
+            self.0.take()
+        }
+
         fn extract(self) -> Self::T {
-            self.0.extract()
+            self.0.take()
         }
     }
 
@@ -252,12 +260,12 @@ mod tests {
     }
 
     #[test]
-    fn test_named_refinement_extract() {
+    fn test_named_refinement_take() {
         let value = Named::<Test, Refinement<u8, boundable::unsigned::LessThan<5>>>(
             Refinement::refine(4).unwrap(),
             PhantomData,
         );
-        let extracted = value.extract();
+        let extracted = value.take();
         assert_eq!(extracted, 4);
     }
 }


### PR DESCRIPTION
take is more idiomatic and consistent with std types

Closes #14 