### PR TITLE
Moves optimization to a Predicate-level implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove `Clone` constraints for all impls.
 - Adds an `optimize` function to the `Predicate` and `StatefulPredicate` traits to prevent possible
   downstream soundness problems from being unintentionally introduced. Thanks to
-  [Scott Taylor](https://github.com/scott2000) and
-  [Nuutti Kotivuori](https://github.com/nakedible-p) for their input!
+  [Scott Taylor](https://github.com/scott2000) and [Nuutti Kotivuori](https://github.com/nakedible)
+  for their input!
 
 ## [0.0.4] - 2025-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- Remove `Clone` constraints for all impls. 
+- Remove `Clone` constraints for all impls.
+- Adds an `optimize` function to the `Predicate` and `StatefulPredicate` traits to prevent possible
+  downstream soundness problems from being unintentionally introduced
 
 ## [0.0.4] - 2025-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove `Clone` constraints for all impls.
 - Adds an `optimize` function to the `Predicate` and `StatefulPredicate` traits to prevent possible
-  downstream soundness problems from being unintentionally introduced
+  downstream soundness problems from being unintentionally introduced. Thanks to
+  [Scott Taylor](https://github.com/scott2000) and
+  [Nuutti Kotivuori](https://github.com/nakedible-p) for their input!
 
 ## [0.0.4] - 2025-03-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refined"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Simple refinement types; parse, don't validate!"
 documentation = "https://docs.rs/refined"

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ functionality that they provide, I had three principles in mind during developme
 are not met by any other library:
 
 - Simplicity: a design that anyone should be able to look at and understand. This immediately rules
-  out any approach include proc macros
+  out any approach that relies upon proc macros
 - Maintainability: it should be simple to keep the library up to date, add functionality, fix bugs,
   etc. Other developers should be able to contribute to the project without difficulty
-- Extensbility: the ability for downstream consumers of the library to easily add their own
+- Extensbility: downstream consumers of the library should be able to easily add their own
   extensions without requiring contribution to the core `refined` library
 
 A direct comparison against some of the more popular options:

--- a/examples/axum/Cargo.lock
+++ b/examples/axum/Cargo.lock
@@ -151,12 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,9 +528,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "litemap"
@@ -625,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "parking_lot"
@@ -678,11 +672,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -732,7 +726,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.21",
+ "zerocopy",
 ]
 
 [[package]]
@@ -784,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "serde",
  "thiserror",
@@ -856,18 +850,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -950,9 +944,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -998,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.38"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb041120f25f8fbe8fd2dbe4671c7c2ed74d83be2e7a77529bf7e0790ae3f472"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -1039,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1311,39 +1305,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
-dependencies = [
- "zerocopy-derive 0.8.21",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/optimized/Cargo.lock
+++ b/examples/optimized/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "serde",
  "thiserror",
@@ -37,18 +37,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/quickstart/Cargo.lock
+++ b/examples/quickstart/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "serde",
  "thiserror",
@@ -37,18 +37,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1739936662,
-        "narHash": "sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk=",
+        "lastModified": 1741481578,
+        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
+        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
         "wrapper-manager": "wrapper-manager"
       },
       "locked": {
-        "lastModified": 1739453252,
-        "narHash": "sha256-jvPsEdO8GFHg7ipKYIOXhSpBhFZOcCIQ/Ab0eQij1QQ=",
+        "lastModified": 1741783969,
+        "narHash": "sha256-BXYB/nsOwBGladoTzga2ogNusBDW/HaKamlQ0saKjVc=",
         "owner": "jkaye2012",
         "repo": "devenv",
-        "rev": "529001d7a3d819ff003a155f5861fc33324cc500",
+        "rev": "a630ab648e4aa6f1c58a242b4bf1466c285c5334",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1740743217,
-        "narHash": "sha256-brsCRzLqimpyhORma84c3W2xPbIidZlIc3JGIuQVSNI=",
+        "lastModified": 1741600792,
+        "narHash": "sha256-yfDy6chHcM7pXpMF4wycuuV+ILSTG486Z/vLx/Bdi6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b27ba4eb322d9d2bf2dc9ada9fd59442f50c8d7c",
+        "rev": "ebe2788eafd539477f83775ef93c3c7e244421d3",
         "type": "github"
       },
       "original": {

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -33,6 +33,12 @@ impl<T> Predicate<T> for True {
     fn error() -> String {
         String::from("true predicate")
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 /// Always `false`.
@@ -46,6 +52,12 @@ impl<T> Predicate<T> for False {
 
     fn error() -> String {
         String::from("false predicate")
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -61,6 +73,12 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for And<A, B> {
     fn error() -> String {
         format!("{} and {}", A::error(), B::error())
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 /// Logical disjunction of two [predicates](Predicate).
@@ -74,6 +92,12 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for Or<A, B> {
 
     fn error() -> String {
         format!("{} or {}", A::error(), B::error())
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -89,6 +113,12 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for Xor<A, B> {
     fn error() -> String {
         format!("{} xor {}", A::error(), B::error())
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 /// Logical negation of a [predicate](Predicate).
@@ -102,6 +132,12 @@ impl<T, P: Predicate<T>> Predicate<T> for Not<P> {
 
     fn error() -> String {
         format!("not {}", P::error())
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 

--- a/src/boolean.rs
+++ b/src/boolean.rs
@@ -34,8 +34,6 @@ impl<T> Predicate<T> for True {
         String::from("true predicate")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -54,8 +52,6 @@ impl<T> Predicate<T> for False {
         String::from("false predicate")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -74,8 +70,6 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for And<A, B> {
         format!("{} and {}", A::error(), B::error())
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -94,8 +88,6 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for Or<A, B> {
         format!("{} or {}", A::error(), B::error())
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -114,8 +106,6 @@ impl<T, A: Predicate<T>, B: Predicate<T>> Predicate<T> for Xor<A, B> {
         format!("{} xor {}", A::error(), B::error())
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -134,8 +124,6 @@ impl<T, P: Predicate<T>> Predicate<T> for Not<P> {
         format!("not {}", P::error())
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }

--- a/src/boundable/signed.rs
+++ b/src/boundable/signed.rs
@@ -127,8 +127,6 @@ impl<T: SignedBoundable, const MIN: isize> Predicate<T> for GreaterThan<MIN> {
         format!("must be greater than {}", MIN)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -148,8 +146,6 @@ impl<T: SignedBoundable, const MIN: isize> Predicate<T> for GreaterThanEqual<MIN
         format!("must be greater than or equal to {}", MIN)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -169,8 +165,6 @@ impl<T: SignedBoundable, const MAX: isize> Predicate<T> for LessThan<MAX> {
         format!("must be less than {}", MAX)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -190,8 +184,6 @@ impl<T: SignedBoundable, const MAX: isize> Predicate<T> for LessThanEqual<MAX> {
         format!("must be less than or equal to {}", MAX)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -217,8 +209,6 @@ impl<T: SignedBoundable, const DIV: isize, const MOD: isize> Predicate<T> for Mo
         format!("must be divisible by {} with a remainder of {}", DIV, MOD)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -242,8 +232,6 @@ impl<T: SignedBoundable, const VAL: isize> Predicate<T> for Equals<VAL> {
         format!("must be equal to {}", VAL)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }

--- a/src/boundable/signed.rs
+++ b/src/boundable/signed.rs
@@ -126,6 +126,12 @@ impl<T: SignedBoundable, const MIN: isize> Predicate<T> for GreaterThan<MIN> {
     fn error() -> String {
         format!("must be greater than {}", MIN)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -140,6 +146,12 @@ impl<T: SignedBoundable, const MIN: isize> Predicate<T> for GreaterThanEqual<MIN
 
     fn error() -> String {
         format!("must be greater than or equal to {}", MIN)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -156,6 +168,12 @@ impl<T: SignedBoundable, const MAX: isize> Predicate<T> for LessThan<MAX> {
     fn error() -> String {
         format!("must be less than {}", MAX)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -170,6 +188,12 @@ impl<T: SignedBoundable, const MAX: isize> Predicate<T> for LessThanEqual<MAX> {
 
     fn error() -> String {
         format!("must be less than or equal to {}", MAX)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -192,6 +216,12 @@ impl<T: SignedBoundable, const DIV: isize, const MOD: isize> Predicate<T> for Mo
     fn error() -> String {
         format!("must be divisible by {} with a remainder of {}", DIV, MOD)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 pub type Divisible<const DIV: isize> = Modulo<DIV, 0>;
@@ -210,6 +240,12 @@ impl<T: SignedBoundable, const VAL: isize> Predicate<T> for Equals<VAL> {
 
     fn error() -> String {
         format!("must be equal to {}", VAL)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 

--- a/src/boundable/unsigned.rs
+++ b/src/boundable/unsigned.rs
@@ -201,6 +201,12 @@ impl<T: UnsignedBoundable, const MAX: usize> Predicate<T> for LessThan<MAX> {
     fn error() -> String {
         format!("must be less than {}", MAX)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -215,6 +221,12 @@ impl<T: UnsignedBoundable, const MAX: usize> Predicate<T> for LessThanEqual<MAX>
 
     fn error() -> String {
         format!("must be less than or equal to {}", MAX)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -236,6 +248,12 @@ impl<T: UnsignedBoundable, const DIV: usize, const MOD: usize> Predicate<T> for 
     fn error() -> String {
         format!("must be divisible by {} with a remainder of {}", DIV, MOD)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 pub type Divisible<const DIV: usize> = Modulo<DIV, 0>;
@@ -243,6 +261,7 @@ pub type Divisible<const DIV: usize> = Modulo<DIV, 0>;
 pub type Even = Modulo<2, 0>;
 
 pub type Odd = Not<Even>;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Equals<const VAL: usize>;
 
@@ -253,6 +272,12 @@ impl<T: UnsignedBoundable, const VAL: usize> Predicate<T> for Equals<VAL> {
 
     fn error() -> String {
         format!("must be equal to {}", VAL)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 

--- a/src/boundable/unsigned.rs
+++ b/src/boundable/unsigned.rs
@@ -171,6 +171,10 @@ impl<T: UnsignedBoundable, const MIN: usize> Predicate<T> for GreaterThan<MIN> {
     fn error() -> String {
         format!("must be greater than {}", MIN)
     }
+
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -185,6 +189,10 @@ impl<T: UnsignedBoundable, const MIN: usize> Predicate<T> for GreaterThanEqual<M
 
     fn error() -> String {
         format!("must be greater than or equal to {}", MIN)
+    }
+
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -202,8 +210,6 @@ impl<T: UnsignedBoundable, const MAX: usize> Predicate<T> for LessThan<MAX> {
         format!("must be less than {}", MAX)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -223,8 +229,6 @@ impl<T: UnsignedBoundable, const MAX: usize> Predicate<T> for LessThanEqual<MAX>
         format!("must be less than or equal to {}", MAX)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -237,6 +241,7 @@ pub type OpenClosedInterval<const MIN: usize, const MAX: usize> = And<GT<MIN>, L
 pub type ClosedOpenInterval<const MIN: usize, const MAX: usize> = And<GTE<MIN>, LT<MAX>>;
 
 pub type ClosedInterval<const MIN: usize, const MAX: usize> = And<GTE<MIN>, LTE<MAX>>;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Modulo<const DIV: usize, const MOD: usize>;
 
@@ -249,8 +254,6 @@ impl<T: UnsignedBoundable, const DIV: usize, const MOD: usize> Predicate<T> for 
         format!("must be divisible by {} with a remainder of {}", DIV, MOD)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -274,8 +277,6 @@ impl<T: UnsignedBoundable, const VAL: usize> Predicate<T> for Equals<VAL> {
         format!("must be equal to {}", VAL)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }

--- a/src/character.rs
+++ b/src/character.rs
@@ -24,8 +24,6 @@ impl Predicate<char> for IsControl {
         String::from("must be a control character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -43,8 +41,6 @@ impl Predicate<char> for IsDigit {
         String::from("must be a digit")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -62,8 +58,6 @@ impl Predicate<char> for IsLowercase {
         String::from("must be a lowercase character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -81,8 +75,6 @@ impl Predicate<char> for IsUppercase {
         String::from("must be an uppercase character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -100,8 +92,6 @@ impl Predicate<char> for IsNumeric {
         String::from("must be a numeric character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -119,8 +109,6 @@ impl Predicate<char> for IsWhitespace {
         String::from("must be a whitespace character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -138,8 +126,6 @@ impl Predicate<char> for IsHexDigit {
         String::from("must be a valid hex character")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &char) {
         std::hint::assert_unchecked(Self::test(value));
     }

--- a/src/character.rs
+++ b/src/character.rs
@@ -23,6 +23,12 @@ impl Predicate<char> for IsControl {
     fn error() -> String {
         String::from("must be a control character")
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -35,6 +41,12 @@ impl Predicate<char> for IsDigit {
 
     fn error() -> String {
         String::from("must be a digit")
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -49,6 +61,12 @@ impl Predicate<char> for IsLowercase {
     fn error() -> String {
         String::from("must be a lowercase character")
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -61,6 +79,12 @@ impl Predicate<char> for IsUppercase {
 
     fn error() -> String {
         String::from("must be an uppercase character")
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -75,6 +99,12 @@ impl Predicate<char> for IsNumeric {
     fn error() -> String {
         String::from("must be a numeric character")
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -88,6 +118,12 @@ impl Predicate<char> for IsWhitespace {
     fn error() -> String {
         String::from("must be a whitespace character")
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -100,6 +136,12 @@ impl Predicate<char> for IsHexDigit {
 
     fn error() -> String {
         String::from("must be a valid hex character")
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &char) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,6 +447,10 @@ pub trait Predicate<T> {
     /// }
     /// ```
     ///
+    /// Note that [std::hint::assert_unchecked] acts as an assert in debug builds, meaning that
+    /// tests should be able to detect correctness issues as well. It is only in optimized builds
+    /// that no check is performed.
+    ///
     /// # Safety
     ///
     /// Implementation of this function takes a _correctness_ property and turns it in to a
@@ -487,6 +491,10 @@ pub trait StatefulPredicate<T>: Default + Predicate<T> {
     ///     std::hint::assert_unchecked(Self::test(value));
     /// }
     /// ```
+    ///
+    /// Note that [std::hint::assert_unchecked] acts as an assert in debug builds, meaning that
+    /// tests should be able to detect correctness issues as well. It is only in optimized builds
+    /// that no check is performed.
     ///
     /// # Safety
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,14 +435,13 @@ pub trait Predicate<T> {
     fn error() -> String;
 
     /// Applies a potentially unsafe optimization to call sites that can take advantage of
-    /// information provided by the predicate.
+    /// information provided by the predicate. This function is unused by `refined` unless
+    /// the `optimized` feature is enabled.
     ///
     /// As all predicate tests _should_ be pure, implementing this function is recommended
     /// for most predicate implementations. The most common implementation will look like:
     ///
     /// ```ignore
-    /// #[cfg(feature = "optimized")]
-    /// #[doc(cfg(feature = "optimized"))]
     /// unsafe fn optimize(value: &T) {
     ///     std::hint::assert_unchecked(Self::test(value));
     /// }
@@ -455,8 +454,6 @@ pub trait Predicate<T> {
     /// lead to undefined behavior. If you have any doubt about the purity of your test
     /// implementation, do not implement this function (and, probably, you should reconsider
     /// your approach).
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(_value: &T) {}
 }
 
@@ -479,14 +476,13 @@ pub trait StatefulPredicate<T>: Default + Predicate<T> {
     }
 
     /// Applies a potentially unsafe optimization to call sites that can take advantage of
-    /// information provided by the predicate.
+    /// information provided by the predicate. This function is unused by `refined` unless
+    /// the `optimized` feature is enabled.
     ///
     /// As all predicate tests _should_ be pure, implementing this function is recommended
     /// for most predicate implementations. The most common implementation will look like:
     ///
     /// ```ignore
-    /// #[cfg(feature = "optimized")]
-    /// #[doc(cfg(feature = "optimized"))]
     /// unsafe fn optimize(value: &T) {
     ///     std::hint::assert_unchecked(Self::test(value));
     /// }
@@ -499,8 +495,6 @@ pub trait StatefulPredicate<T>: Default + Predicate<T> {
     /// lead to undefined behavior. If you have any doubt about the purity of your test
     /// implementation, do not implement this function (and, probably, you should reconsider
     /// your approach).
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(_value: &T) {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,14 @@ macro_rules! type_string {
 /// An assertion that must hold for an instance of a type to be considered refined.
 pub trait Predicate<T> {
     /// Whether a value satisfies the predicate.
+    ///
+    /// # Safety
+    ///
+    /// Implementations of this method **must** be pure functions. They must be infallible and
+    /// must always return the same result when provided the same input value. If you have a
+    /// situation that requires impurity to "materialize" a predicate, use the [Default::default]
+    /// implementation of a [StatefulPredicate]. Even then, under no circumstance can the `test`
+    /// function itself be impure.
     fn test(value: &T) -> bool;
 
     /// An error message to display when the predicate doesn't hold.

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -7,7 +7,9 @@ pub use named::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{Predicate, Refined, RefinementError, RefinementOps, StatefulRefinementOps};
+use crate::{
+    Predicate, Refined, RefinementError, RefinementOps, StatefulPredicate, StatefulRefinementOps,
+};
 
 #[cfg(feature = "implication")]
 use crate::Implies;
@@ -43,7 +45,7 @@ impl<T, P: Predicate<T>> RefinementOps for Refinement<T, P> {
     fn take(self) -> T {
         #[cfg(feature = "optimized")]
         unsafe {
-            std::hint::assert_unchecked(P::test(&self.0));
+            P::optimize(&self.0);
         }
         self.0
     }
@@ -51,7 +53,7 @@ impl<T, P: Predicate<T>> RefinementOps for Refinement<T, P> {
     fn extract(self) -> T {
         #[cfg(feature = "optimized")]
         unsafe {
-            std::hint::assert_unchecked(P::test(&self.0));
+            P::optimize(&self.0);
         }
         self.0
     }
@@ -69,7 +71,7 @@ impl<T, P: Predicate<T>> std::ops::Deref for Refinement<T, P> {
     fn deref(&self) -> &Self::Target {
         #[cfg(feature = "optimized")]
         unsafe {
-            std::hint::assert_unchecked(P::test(&self.0));
+            P::optimize(&self.0);
         }
         &self.0
     }
@@ -101,25 +103,6 @@ where
 {
     fn imply(self) -> Refinement<Type, T> {
         Refinement(self.0, PhantomData)
-    }
-}
-
-/// A stateful assertion that must hold for an instance of a type to be considered refined.
-pub trait StatefulPredicate<T>: Default + Predicate<T> {
-    /// Whether a value satisfies the predicate.
-    ///
-    /// # Safety
-    ///
-    /// Implementations of this method **must** be pure functions. They must be infallible and
-    /// must always return the same result when provided the same input value. If you have a
-    /// situation that requires impurity to "materialize" a predicate, use the [Default::default]
-    /// implementation to "inject" that logic into the predicate. Even then, under no circumstance
-    /// can the `test` function itself be impure.
-    fn test(&self, value: &T) -> bool;
-
-    /// An error message to display when the predicate doesn't hold.
-    fn error(&self) -> String {
-        <Self as Predicate<T>>::error()
     }
 }
 

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -107,6 +107,14 @@ where
 /// A stateful assertion that must hold for an instance of a type to be considered refined.
 pub trait StatefulPredicate<T>: Default + Predicate<T> {
     /// Whether a value satisfies the predicate.
+    ///
+    /// # Safety
+    ///
+    /// Implementations of this method **must** be pure functions. They must be infallible and
+    /// must always return the same result when provided the same input value. If you have a
+    /// situation that requires impurity to "materialize" a predicate, use the [Default::default]
+    /// implementation to "inject" that logic into the predicate. Even then, under no circumstance
+    /// can the `test` function itself be impure.
     fn test(&self, value: &T) -> bool;
 
     /// An error message to display when the predicate doesn't hold.

--- a/src/string.rs
+++ b/src/string.rs
@@ -30,8 +30,6 @@ impl<T: AsRef<str>, Prefix: TypeString> Predicate<T> for StartsWith<Prefix> {
         format!("must start with '{}'", Prefix::VALUE)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -49,8 +47,6 @@ impl<T: AsRef<str>, Suffix: TypeString> Predicate<T> for EndsWith<Suffix> {
         format!("must end with '{}'", Suffix::VALUE)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -68,8 +64,6 @@ impl<T: AsRef<str>, Substr: TypeString> Predicate<T> for Contains<Substr> {
         format!("must contain '{}'", Substr::VALUE)
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -87,8 +81,6 @@ impl<T: AsRef<str>> Predicate<T> for Trimmed {
         String::from("must not start or end with whitespace")
     }
 
-    #[cfg(feature = "optimized")]
-    #[doc(cfg(feature = "optimized"))]
     unsafe fn optimize(value: &T) {
         std::hint::assert_unchecked(Self::test(value));
     }
@@ -114,8 +106,6 @@ mod regex_pred {
             format!("must match regular expression {}", S::VALUE)
         }
 
-        #[cfg(feature = "optimized")]
-        #[doc(cfg(feature = "optimized"))]
         unsafe fn optimize(value: &T) {
             std::hint::assert_unchecked(<Self as Predicate<T>>::test(value));
         }
@@ -135,8 +125,6 @@ mod regex_pred {
             self.0.is_match(value.as_ref())
         }
 
-        #[cfg(feature = "optimized")]
-        #[doc(cfg(feature = "optimized"))]
         unsafe fn optimize(value: &T) {
             std::hint::assert_unchecked(<Self as Predicate<T>>::test(value));
         }

--- a/src/string.rs
+++ b/src/string.rs
@@ -29,6 +29,12 @@ impl<T: AsRef<str>, Prefix: TypeString> Predicate<T> for StartsWith<Prefix> {
     fn error() -> String {
         format!("must start with '{}'", Prefix::VALUE)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -41,6 +47,12 @@ impl<T: AsRef<str>, Suffix: TypeString> Predicate<T> for EndsWith<Suffix> {
 
     fn error() -> String {
         format!("must end with '{}'", Suffix::VALUE)
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -55,6 +67,12 @@ impl<T: AsRef<str>, Substr: TypeString> Predicate<T> for Contains<Substr> {
     fn error() -> String {
         format!("must contain '{}'", Substr::VALUE)
     }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -67,6 +85,12 @@ impl<T: AsRef<str>> Predicate<T> for Trimmed {
 
     fn error() -> String {
         String::from("must not start or end with whitespace")
+    }
+
+    #[cfg(feature = "optimized")]
+    #[doc(cfg(feature = "optimized"))]
+    unsafe fn optimize(value: &T) {
+        std::hint::assert_unchecked(Self::test(value));
     }
 }
 
@@ -89,6 +113,12 @@ mod regex_pred {
         fn error() -> String {
             format!("must match regular expression {}", S::VALUE)
         }
+
+        #[cfg(feature = "optimized")]
+        #[doc(cfg(feature = "optimized"))]
+        unsafe fn optimize(value: &T) {
+            std::hint::assert_unchecked(<Self as Predicate<T>>::test(value));
+        }
     }
 
     impl<S: TypeString> Default for Regex<S> {
@@ -103,6 +133,12 @@ mod regex_pred {
     impl<S: TypeString, T: AsRef<str>> StatefulPredicate<T> for Regex<S> {
         fn test(&self, value: &T) -> bool {
             self.0.is_match(value.as_ref())
+        }
+
+        #[cfg(feature = "optimized")]
+        #[doc(cfg(feature = "optimized"))]
+        unsafe fn optimize(value: &T) {
+            std::hint::assert_unchecked(<Self as Predicate<T>>::test(value));
         }
     }
 


### PR DESCRIPTION
There was a potential safety issue introduced in `0.0.4` if users implemented predicates in an impure manner. Really, doing so doesn't make much sense, but even still it should be impossible to invoke undefined behavior without the user dropping into `unsafe`.