### PR TITLE
Fixes the ability to build on stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.3.1] - 2025-03-30
+
+- Fixes an inability to build using the `stable` toolchain caused by indiscriminate usage of the
+  unstable `doc_cfg` feature
+
 ## [0.3.0] - 2025-03-25
 
 - Adds the `alloc` feature flag, providing support for `no_std` without requiring the use of an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const_format",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refined"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Simple refinement types; parse, don't validate!"
 documentation = "https://docs.rs/refined"
@@ -30,3 +30,4 @@ optimized = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = [ "--cfg", "docsrs" ]

--- a/examples/axum/Cargo.lock
+++ b/examples/axum/Cargo.lock
@@ -56,9 +56,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
@@ -90,12 +90,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "17.2.0"
+version = "17.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317c1f4ecc1e68e0ad5decb78478421055c963ce215e736ed97463fa609cd196"
+checksum = "0eb1dfb84bd48bad8e4aa1acb82ed24c2bb5e855b659959b4e03b4dca118fcac"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -167,9 +167,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "1.3.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cfg-if"
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -550,12 +550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchit"
@@ -600,16 +594,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -648,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -813,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const_format",
  "regex",
@@ -866,26 +850,24 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reserve-port"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359fc315ed556eb0e42ce74e76f4b1cd807b50fa6307f3de4e51f92dbe86e2d5"
+checksum = "ba3747658ee2585ecf5607fa9887c92eff61b362ff5253dbf797dfeb73d33d78"
 dependencies = [
- "lazy_static",
  "thiserror",
 ]
 
 [[package]]
 name = "rust-multipart-rfc7578_2"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4bb9e7c9abe5fa5f30c2d8f8fefb9e0080a2c1e3c2e567318d2907054b35d3"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "mime",
- "mime_guess",
  "rand 0.9.0",
  "thiserror",
 ]
@@ -1058,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1079,9 +1061,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1179,12 +1161,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -1377,18 +1353,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/optimized/Cargo.lock
+++ b/examples/optimized/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const_format",
  "regex",

--- a/examples/quickstart/Cargo.lock
+++ b/examples/quickstart/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "refined"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const_format",
  "regex",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1742085745,
-        "narHash": "sha256-QkT5Bg6m40We/w9n5ljCsWRJs29qQM6+MztDBduYvfU=",
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "1715a8fa7258bcf74ff645541d8d4ab4c53c4f6b",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1741862977,
-        "narHash": "sha256-prZ0M8vE/ghRGGZcflvxCu40ObKaB+ikn74/xQoNrGQ=",
+        "lastModified": 1743231893,
+        "narHash": "sha256-tpJsHMUPEhEnzySoQxx7+kA+KUtgWqvlcUBqROYNNt0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cdd2ef009676ac92b715ff26630164bb88fec4e0",
+        "rev": "c570c1f5304493cafe133b8d843c7c1c4a10d3a6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         fenix' = fenix.packages.${system};
         crane' = (crane.mkLib pkgs).overrideToolchain fenix'.complete.toolchain;
+        crane-stable = (crane.mkLib pkgs).overrideToolchain fenix'.stable.minimalToolchain;
         manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
 
         src = crane'.cleanCargoSource ./.;
@@ -60,6 +61,11 @@
         refined = crane'.buildPackage {
           inherit src;
           cargoTestExtraArgs = "--all-features";
+        };
+
+        refined-stable = crane-stable.buildPackage {
+          inherit src;
+          cargoTestExtraArgs = "--lib";
         };
 
         refined-no-std = crane'.buildPackage {
@@ -109,11 +115,14 @@
             linuxPackages_latest.perf
             lldb
           ];
+
+          RUSTDOCFLAGS = "--cfg docsrs";
         };
 
         checks.${system} = {
           inherit
             refined
+            refined-stable
             refined-no-std
             refined-doc
             refined-example-axum

--- a/src/implication/mod.rs
+++ b/src/implication/mod.rs
@@ -50,10 +50,10 @@ impl IsTrue for Assert<true> {}
 mod boolean_imp;
 mod boundable_imp;
 
-#[doc(cfg(feature = "arithmetic"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[cfg(feature = "arithmetic")]
 mod arithmetic;
 
-#[doc(cfg(feature = "arithmetic"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "arithmetic")))]
 #[cfg(feature = "arithmetic")]
 pub use arithmetic::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@
     allow(incomplete_features),
     feature(generic_const_exprs)
 )]
-#![feature(doc_cfg)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]
@@ -393,7 +393,7 @@ pub mod boolean;
 pub mod boundable;
 pub mod character;
 pub mod prelude;
-#[doc(cfg(feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub mod string;
 
@@ -403,10 +403,10 @@ pub use refinement::*;
 pub use boundable::signed::SignedBoundable;
 pub use boundable::unsigned::UnsignedBoundable;
 
-#[doc(cfg(feature = "implication"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "implication")))]
 #[cfg(feature = "implication")]
 pub mod implication;
-#[doc(cfg(feature = "implication"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "implication")))]
 #[cfg(feature = "implication")]
 pub use implication::*;
 
@@ -548,7 +548,7 @@ pub struct Refined<T>(T);
 pub struct RefinementError(ErrorMessage);
 
 #[cfg(feature = "alloc")]
-#[doc(cfg(feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Display for RefinementError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "refinement violated: {}", self.0)

--- a/src/refinement/mod.rs
+++ b/src/refinement/mod.rs
@@ -3,7 +3,7 @@ mod named;
 
 use core::{fmt::Display, marker::PhantomData};
 
-#[doc(cfg(feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub use named::*;
 
@@ -23,7 +23,7 @@ use crate::Implies;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Refinement<T, P: Predicate<T>>(pub(crate) T, pub(crate) PhantomData<P>);
 
-#[doc(cfg(feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 #[cfg(feature = "serde")]
 impl<T: Serialize, P: Predicate<T>> Serialize for Refinement<T, P> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -34,7 +34,7 @@ impl<T: Serialize, P: Predicate<T>> Serialize for Refinement<T, P> {
     }
 }
 
-#[doc(cfg(all(feature = "serde", feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "serde", feature = "alloc"))))]
 #[cfg(all(feature = "serde", feature = "alloc"))]
 impl<'de, T: Deserialize<'de>, P: Predicate<T>> Deserialize<'de> for Refinement<T, P> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -102,7 +102,7 @@ impl<T, P: Predicate<T>> TryFrom<Refined<T>> for Refinement<T, P> {
     }
 }
 
-#[doc(cfg(feature = "implication"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "implication")))]
 #[cfg(feature = "implication")]
 impl<F, T, Type> Implies<Refinement<Type, T>> for Refinement<Type, F>
 where

--- a/src/refinement/named.rs
+++ b/src/refinement/named.rs
@@ -82,7 +82,7 @@ impl<N: TypeString, T, P: StatefulPredicate<T>, R: StatefulRefinementOps<T, P>>
 }
 
 #[cfg(feature = "serde")]
-#[doc(cfg(feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod named_serde {
     use super::*;
     use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/src/string.rs
+++ b/src/string.rs
@@ -88,7 +88,7 @@ impl<T: AsRef<str>> Predicate<T> for Trimmed {
 }
 
 #[cfg(feature = "regex")]
-#[doc(cfg(feature = "regex"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
 mod regex_pred {
     use super::*;
     use crate::StatefulPredicate;


### PR DESCRIPTION
doc_cfg is now gated behind conditional compilation that can be run only during development and the docs.rs build. Also adds CI builds and tests against a minimal stable toolchain to prevent future regression.

Closes #37 