### PR TITLE
fix: hygiene of macro

### DIFF
--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -2,7 +2,7 @@
 
 use refined::{
     boundable::unsigned::{ClosedInterval, LessThanEqual},
-    type_string, Named, Refinement, RefinementError, RefinementOps, TypeString,
+    type_string, Named, Refinement, RefinementError, RefinementOps, 
 };
 
 type_string!(Name, "name");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,9 +422,7 @@ pub trait TypeString: Default {
 ///
 /// `$name` is the name of a type to create to hold the type-level string.
 /// `$value` is the string that should be lifted into the type system.
-///
-/// Note that use of this macro requires that [TypeString] is in scope.
-///
+/// 
 /// # Example
 ///
 /// ```
@@ -438,7 +436,7 @@ macro_rules! type_string {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
         pub struct $name;
 
-        impl TypeString for $name {
+        impl $crate::TypeString for $name {
             const VALUE: &'static str = $value;
         }
     };

--- a/src/refinement/named.rs
+++ b/src/refinement/named.rs
@@ -15,7 +15,7 @@ use crate::{
 /// # Example
 ///
 /// ```
-/// use refined::{type_string, TypeString, Named, Refinement, RefinementOps, boundable::unsigned::GreaterThan};
+/// use refined::{type_string, Named, Refinement, RefinementOps, boundable::unsigned::GreaterThan};
 ///
 /// type_string!(Example, "example name");
 ///


### PR DESCRIPTION
hello 

I tested this library, it's good.

when a test to use type_string i need import TypeString 

but have solution recommend here : https://doc.rust-lang.org/reference/macros-by-example.html#r-macro.decl.hygiene.vis

David